### PR TITLE
Add `XCUIDevice` extension to query if in dark vs light mode

### DIFF
--- a/PlaygroundAppUITests/PlaygroundAppUITests.swift
+++ b/PlaygroundAppUITests/PlaygroundAppUITests.swift
@@ -20,10 +20,5 @@ class PlaygroundAppUITests: XCTestCase {
         app.staticTexts.forEach {
             XCTAssertNotNil($0.value as? String)
         }
-
-        // We can't control the device appearance mode (light vs dark) from the tests, so we just
-        // check the method returns consistent results
-        XCTAssertNotEqual(XCUIDevice.userInterfaceStyle, .unspecified)
-        XCTAssertNotEqual(XCUIDevice.inDarkMode, XCUIDevice.inLightMode)
     }
 }

--- a/PlaygroundAppUITests/PlaygroundAppUITests.swift
+++ b/PlaygroundAppUITests/PlaygroundAppUITests.swift
@@ -20,5 +20,10 @@ class PlaygroundAppUITests: XCTestCase {
         app.staticTexts.forEach {
             XCTAssertNotNil($0.value as? String)
         }
+
+        // We can't control the device appearance mode (light vs dark) from the tests, so we just
+        // check the method returns consistent results
+        XCTAssertNotEqual(XCUIDevice.userInterfaceStyle, .unspecified)
+        XCTAssertNotEqual(XCUIDevice.inDarkMode, XCUIDevice.inLightMode)
     }
 }

--- a/PlaygroundAppUITests/XCUIDevice+UserInterfaceStyleTests.swift
+++ b/PlaygroundAppUITests/XCUIDevice+UserInterfaceStyleTests.swift
@@ -1,0 +1,12 @@
+import XCUITestHelpers
+import XCTest
+
+class XCUIDeviceUserInterfaceStyleTests: XCTestCase {
+
+    func testReadingUserInterfaceStyleReturnsConsistentValues() {
+        // We can't control the device appearance mode (light vs dark) from the tests, so we just
+        // check the method returns consistent results
+        XCTAssertNotEqual(XCUIDevice.userInterfaceStyle, .unspecified)
+        XCTAssertNotEqual(XCUIDevice.inDarkMode, XCUIDevice.inLightMode)
+    }
+}

--- a/Sources/XCUITestHelpers/XCUIDevice+UserInterfaceStyle.swift
+++ b/Sources/XCUITestHelpers/XCUIDevice+UserInterfaceStyle.swift
@@ -1,0 +1,32 @@
+import UIKit
+import XCTest
+
+public extension XCUIDevice {
+
+    /// The device `UIUserInterfaceStyle`.
+    ///
+    /// This is declared as `static` rather than at the instance level to make it easier to call.
+    /// The UI tests thread can't run on multiple devices at the same time, so there is no strict
+    /// need to read this value from an instance.
+    static var userInterfaceStyle: UIUserInterfaceStyle {
+        UIViewController().traitCollection.userInterfaceStyle
+    }
+
+    /// Whether the device is in dark mode
+    ///
+    /// This is declared as `static` rather than at the instance level to make it easier to call.
+    /// The UI tests thread can't run on multiple devices at the same time, so there is no strict
+    /// need to read this value from an instance.
+    static var inDarkMode: Bool {
+        userInterfaceStyle == .dark
+    }
+
+    /// Whether the device is in dark mode
+    ///
+    /// This is declared as `static` rather than at the instance level to make it easier to call.
+    /// The UI tests thread can't run on multiple devices at the same time, so there is no strict
+    /// need to read this value from an instance.
+    static var inLightMode: Bool {
+        userInterfaceStyle == .light
+    }
+}

--- a/XCUITestHelpers.xcodeproj/project.pbxproj
+++ b/XCUITestHelpers.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		3F762E8B26777BAF0088CD45 /* XCUITestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F762E8926777BAF0088CD45 /* XCUITestHelpers.swift */; };
 		3F762E8C26777BAF0088CD45 /* XCUITestHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F762E8A26777BAF0088CD45 /* XCUITestHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3F8CDAD926C2261F00A4A814 /* XCUIDevice+UserInterfaceStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8CDAD826C2261F00A4A814 /* XCUIDevice+UserInterfaceStyleTests.swift */; };
 		3FDF285326C1EC5E0027CF19 /* XCUIDevice+UserInterfaceStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FDF285226C1EC5E0027CF19 /* XCUIDevice+UserInterfaceStyle.swift */; };
 		3FF1424F266DB46C00138163 /* XCUITestHelpers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FF1423C266DB44900138163 /* XCUITestHelpers.framework */; };
 		3FF14261266DB7AB00138163 /* XCUITestHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF1425F266DB7AB00138163 /* XCUITestHelpersTests.swift */; };
@@ -47,6 +48,7 @@
 /* Begin PBXFileReference section */
 		3F762E8926777BAF0088CD45 /* XCUITestHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCUITestHelpers.swift; sourceTree = "<group>"; };
 		3F762E8A26777BAF0088CD45 /* XCUITestHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XCUITestHelpers.h; sourceTree = "<group>"; };
+		3F8CDAD826C2261F00A4A814 /* XCUIDevice+UserInterfaceStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIDevice+UserInterfaceStyleTests.swift"; sourceTree = "<group>"; };
 		3FDF285226C1EC5E0027CF19 /* XCUIDevice+UserInterfaceStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIDevice+UserInterfaceStyle.swift"; sourceTree = "<group>"; };
 		3FF1423C266DB44900138163 /* XCUITestHelpers.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = XCUITestHelpers.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3FF14240266DB44900138163 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -182,6 +184,7 @@
 			children = (
 				3FF1429B266DB85500138163 /* Info.plist */,
 				3FF14299266DB85500138163 /* PlaygroundAppUITests.swift */,
+				3F8CDAD826C2261F00A4A814 /* XCUIDevice+UserInterfaceStyleTests.swift */,
 			);
 			path = PlaygroundAppUITests;
 			sourceTree = "<group>";
@@ -396,6 +399,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3F8CDAD926C2261F00A4A814 /* XCUIDevice+UserInterfaceStyleTests.swift in Sources */,
 				3FF1429A266DB85500138163 /* PlaygroundAppUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/XCUITestHelpers.xcodeproj/project.pbxproj
+++ b/XCUITestHelpers.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		3F762E8B26777BAF0088CD45 /* XCUITestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F762E8926777BAF0088CD45 /* XCUITestHelpers.swift */; };
 		3F762E8C26777BAF0088CD45 /* XCUITestHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F762E8A26777BAF0088CD45 /* XCUITestHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3FDF285326C1EC5E0027CF19 /* XCUIDevice+UserInterfaceStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FDF285226C1EC5E0027CF19 /* XCUIDevice+UserInterfaceStyle.swift */; };
 		3FF1424F266DB46C00138163 /* XCUITestHelpers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FF1423C266DB44900138163 /* XCUITestHelpers.framework */; };
 		3FF14261266DB7AB00138163 /* XCUITestHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF1425F266DB7AB00138163 /* XCUITestHelpersTests.swift */; };
 		3FF14262266DB7AB00138163 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF14260266DB7AB00138163 /* XCTestManifests.swift */; };
@@ -46,6 +47,7 @@
 /* Begin PBXFileReference section */
 		3F762E8926777BAF0088CD45 /* XCUITestHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCUITestHelpers.swift; sourceTree = "<group>"; };
 		3F762E8A26777BAF0088CD45 /* XCUITestHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XCUITestHelpers.h; sourceTree = "<group>"; };
+		3FDF285226C1EC5E0027CF19 /* XCUIDevice+UserInterfaceStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIDevice+UserInterfaceStyle.swift"; sourceTree = "<group>"; };
 		3FF1423C266DB44900138163 /* XCUITestHelpers.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = XCUITestHelpers.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3FF14240266DB44900138163 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3FF1424A266DB46C00138163 /* XCUITestHelpersTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = XCUITestHelpersTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -132,6 +134,7 @@
 			children = (
 				3FF14240266DB44900138163 /* Info.plist */,
 				3FF142C1266DBA3500138163 /* XCUIApplication+Device.swift */,
+				3FDF285226C1EC5E0027CF19 /* XCUIDevice+UserInterfaceStyle.swift */,
 				3FF142C2266DBA3500138163 /* XCUIElement+TextManagement.swift */,
 				3FF142C3266DBA3500138163 /* XCUIElementQuery+Sequence.swift */,
 				3F762E8A26777BAF0088CD45 /* XCUITestHelpers.h */,
@@ -362,6 +365,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3FDF285326C1EC5E0027CF19 /* XCUIDevice+UserInterfaceStyle.swift in Sources */,
 				3F762E8B26777BAF0088CD45 /* XCUITestHelpers.swift in Sources */,
 				3FF142C5266DBA3500138163 /* XCUIElement+TextManagement.swift in Sources */,
 				3FF142C4266DBA3500138163 /* XCUIApplication+Device.swift in Sources */,


### PR DESCRIPTION
I wrote lightweight tests for this feature, but see testing instructions in https://github.com/Automattic/simplenote-ios/pull/1392 for "manual" testing.