### PR TITLE
Correctly specify test target dependency to avoid cyclic dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         ),
         .testTarget(
             name: "XCUITestHelpersTests",
-            dependencies: ["XCUITestHelpersTests"],
+            dependencies: ["XCUITestHelpers"],
             exclude: ["Info.plist"]
         ),
     ],


### PR DESCRIPTION
Hat tip @pachlava, see [here](https://github.com/Automattic/XCUITestHelpers/pull/1#discussion_r688379596).

I did see that error before, but always blamed it on Xcode and never took the time to look into it 🤦‍♂️😳.

If you open the project now, it should show that error.