### PR TITLE
Add new helper logic extracted from WooCommerce iOS

### DIFF
--- a/PlaygroundApp/ContentView.swift
+++ b/PlaygroundApp/ContentView.swift
@@ -12,16 +12,42 @@ struct DummyListItem: Identifiable {
         }
 }
 
+struct MonospacedText: View {
+
+    let text: String
+
+    init(_ text: String) {
+        self.text = text
+    }
+
+    var body: some View {
+        Text(text).font(.system(.body, design: .monospaced))
+    }
+}
+
 struct ContentView: View {
     @State var text = "button has not been tapped"
 
     var body: some View {
         VStack {
-            Text(text)
-                .padding()
+            Text(text).padding()
             Button("button") {
                 text = "button was tapped"
             }
+            .padding()
+
+            // Using monospace font to ensure constant relative positioning.
+            HStack {
+                MonospacedText("x1-y1")
+                MonospacedText("x2-y1")
+                MonospacedText("x3-y1")
+            }
+            HStack {
+                MonospacedText("x1-y2")
+                MonospacedText("x2-y2")
+                MonospacedText("x3-y2")
+            }
+
             List(DummyListItem.dummyValues) { item in
                 Text(item.text)
             }

--- a/PlaygroundApp/ContentView.swift
+++ b/PlaygroundApp/ContentView.swift
@@ -1,13 +1,30 @@
 import SwiftUI
 
+struct DummyListItem: Identifiable {
+
+    let text: String
+
+    var id: String { text }
+
+    static let dummyValues: [DummyListItem] = "abcdefghijklmnopqrstuvwxyz"
+        .map { char in
+            DummyListItem(text: String(char))
+        }
+}
+
 struct ContentView: View {
     @State var text = "button has not been tapped"
 
     var body: some View {
-        Text(text)
-            .padding()
-        Button("button") {
-            text = "button was tapped"
+        VStack {
+            Text(text)
+                .padding()
+            Button("button") {
+                text = "button was tapped"
+            }
+            List(DummyListItem.dummyValues) { item in
+                Text(item.text)
+            }
         }
     }
 }

--- a/PlaygroundApp/ContentView.swift
+++ b/PlaygroundApp/ContentView.swift
@@ -1,56 +1,72 @@
 import SwiftUI
 
-struct DummyListItem: Identifiable {
-
-    let text: String
-
-    var id: String { text }
-
-    static let dummyValues: [DummyListItem] = "abcdefghijklmnopqrstuvwxyz"
-        .map { char in
-            DummyListItem(text: String(char))
-        }
-}
-
-struct MonospacedText: View {
-
-    let text: String
-
-    init(_ text: String) {
-        self.text = text
-    }
+struct ContentView: View {
 
     var body: some View {
-        Text(text).font(.system(.body, design: .monospaced))
+        VStack(spacing: 20) {
+            StatefulTextWithButton()
+            Matrix()
+            DummyList()
+        }
     }
 }
 
-struct ContentView: View {
+/// A view consisting of a text label and a button. When the button is tapped, the text in the
+/// label changes.
+struct StatefulTextWithButton: View {
+
     @State var text = "button has not been tapped"
 
     var body: some View {
         VStack {
-            Text(text).padding()
+            Text(text)
             Button("button") {
                 text = "button was tapped"
             }
-            .padding()
+        }
+    }
+}
 
-            // Using monospace font to ensure constant relative positioning.
-            HStack {
-                MonospacedText("x1-y1")
-                MonospacedText("x2-y1")
-                MonospacedText("x3-y1")
-            }
-            HStack {
-                MonospacedText("x1-y2")
-                MonospacedText("x2-y2")
-                MonospacedText("x3-y2")
-            }
+/// A view with a matrix of text subviews. Use it to test methods that compute how views are relative to
+/// each other
+struct Matrix: View {
 
-            List(DummyListItem.dummyValues) { item in
-                Text(item.text)
+    var body: some View {
+        VStack {
+            HStack {
+                Text("x1-y1")
+                Text("x2-y1")
+                Text("x3-y1")
             }
+            HStack {
+                Text("x1-y2")
+                Text("x2-y2")
+                Text("x3-y2")
+            }
+        }
+        // Using monospace font to ensure constant relative positioning.
+        .font(.system(.body, design: .monospaced))
+    }
+}
+
+/// A `List` showing dummy items. Use it to test basic list interaction behaviors, like scrolling
+/// and finding cells.
+struct DummyList: View {
+
+    struct Item: Identifiable {
+
+        let text: String
+
+        var id: String { text }
+    }
+
+    /// An array of `DummyList.Item`s with each element representing a letter of the English
+    /// alphabet.
+    let values: [Item] = "abcdefghijklmnopqrstuvwxyz".map { Item(text: "\($0)") }
+
+    var body: some View {
+        List(values) { item in
+            Text(item.text)
         }
     }
 }

--- a/PlaygroundApp/ContentView.swift
+++ b/PlaygroundApp/ContentView.swift
@@ -1,9 +1,14 @@
 import SwiftUI
 
 struct ContentView: View {
+    @State var text = "button has not been tapped"
+
     var body: some View {
-        Text("Hello, World!")
+        Text(text)
             .padding()
+        Button("button") {
+            text = "button was tapped"
+        }
     }
 }
 

--- a/PlaygroundAppUITests/PlaygroundAppUITests.swift
+++ b/PlaygroundAppUITests/PlaygroundAppUITests.swift
@@ -14,11 +14,22 @@ class PlaygroundAppUITests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
 
-        XCTAssertTrue(app.staticTexts[XCUITestHelpers().text].exists)
+        XCTAssertTrue(app.staticTexts["button has not been tapped"].exists)
+        XCTAssertFalse(app.staticTexts["button was tapped"].exists)
 
         // This verifies the XCUIElementQuery+Sequence extension works
         app.staticTexts.forEach {
             XCTAssertNotNil($0.value as? String)
         }
+
+        let button = app.buttons["button"]
+        // This is a shallow test... To make it actually verify asynchronous behavior, we should
+        // make the button start as interactive and update after a few moments.
+        XCTAssertTrue(button.waitForIsHittable())
+
+        button.tap()
+
+        XCTAssertFalse(app.staticTexts["button has not been tapped"].exists)
+        XCTAssertTrue(app.staticTexts["button was tapped"].exists)
     }
 }

--- a/PlaygroundAppUITests/PlaygroundAppUITests.swift
+++ b/PlaygroundAppUITests/PlaygroundAppUITests.swift
@@ -6,21 +6,27 @@ import XCTest
 
 class PlaygroundAppUITests: XCTestCase {
 
+    let app = XCUIApplication()
+
     override func setUpWithError() throws {
         continueAfterFailure = false
+        app.launch()
     }
 
-    func testExample() throws {
-        let app = XCUIApplication()
-        app.launch()
-
-        XCTAssertTrue(app.staticTexts["button has not been tapped"].exists)
-        XCTAssertFalse(app.staticTexts["button was tapped"].exists)
-
-        // This verifies the XCUIElementQuery+Sequence extension works
+    func testElementQueryIterator() {
+        // This verifies the `XCUIElementQuery+Sequence` extension works by exercising the `forEach`
+        // method the extension makes available.
         app.staticTexts.forEach {
             XCTAssertNotNil($0.value as? String)
         }
+    }
+
+    func testWaitForIsHittable() {
+        let buttonNotTappedText = "button has not been tapped"
+        let buttonTappedText = "button was tapped"
+
+        XCTAssertTrue(app.staticTexts[buttonNotTappedText].exists)
+        XCTAssertFalse(app.staticTexts[buttonTappedText].exists)
 
         let button = app.buttons["button"]
         // This is a shallow test... To make it actually verify asynchronous behavior, we should

--- a/PlaygroundAppUITests/PlaygroundAppUITests.swift
+++ b/PlaygroundAppUITests/PlaygroundAppUITests.swift
@@ -29,7 +29,7 @@ class PlaygroundAppUITests: XCTestCase {
 
         button.tap()
 
-        XCTAssertFalse(app.staticTexts["button has not been tapped"].exists)
-        XCTAssertTrue(app.staticTexts["button was tapped"].exists)
+        XCTAssertFalse(app.staticTexts[buttonNotTappedText].exists)
+        XCTAssertTrue(app.staticTexts[buttonTappedText].exists)
     }
 }

--- a/PlaygroundAppUITests/XCUIApplication+StatusBarTests.swift
+++ b/PlaygroundAppUITests/XCUIApplication+StatusBarTests.swift
@@ -1,0 +1,44 @@
+import XCUITestHelpers
+import XCTest
+
+class XCUIApplicationStatusBarTests: XCTestCase {
+
+    let app = XCUIApplication()
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app.launch()
+    }
+
+    func testTapStatusBar() throws {
+        let getFirstListElement = { self.app.staticTexts["a"].firstMatch }
+        let getLastListElement = { self.app.staticTexts["z"].firstMatch }
+
+        // Ensure the list is in the default initial position by checking that the first element is
+        // hittable and the last isn't (meaning it's offscreen).
+        XCTAssertTrue(getFirstListElement().isHittable)
+        XCTAssertFalse(getLastListElement().isHittable)
+
+        var attempts = 0
+        let attemptsThreshold = 5
+        while getLastListElement().isHittable == false && attempts < attemptsThreshold {
+            app.swipeUp()
+            attempts += 1
+        }
+
+        // The while loop above ensures that the scroll occurred by verifying the last list element
+        // has become hittable (is now on screen). Let's double-check it by asserting the first
+        // element is no longer hittable
+        XCTAssertFalse(getFirstListElement().isHittable)
+        XCTAssertTrue(getLastListElement().isHittable)
+
+        app.tapStatusBar()
+
+        // Let's now verify the tap on the status bar was successful by mean of checking that the
+        // list returned to the initial position.
+        //
+        // We use `waitForIsHittable` here to give time to the scroll to finish.
+        XCTAssertTrue(getFirstListElement().waitForIsHittable())
+        XCTAssertFalse(getLastListElement().isHittable)
+    }
+}

--- a/PlaygroundAppUITests/XCUIDeviceUserInterfaceIdiomTests.swift
+++ b/PlaygroundAppUITests/XCUIDeviceUserInterfaceIdiomTests.swift
@@ -1,0 +1,13 @@
+import XCUITestHelpers
+import XCTest
+
+class XCUIDeviceUserInterfaceIdiomTests: XCTestCase {
+
+    func testUserInterfaceIdiom() {
+        // To keep this test flexible, let's just verify the result we're getting is consistent.
+        // If `XCUIDevice` tells us it's a phone then is should not be a pad, and vice versa.
+        XCTAssertNotEqual(XCUIDevice.userInterfaceIdiom, .unspecified)
+        XCTAssertNotEqual(XCUIDevice.isPhone, XCUIDevice.isPad)
+    }
+}
+

--- a/PlaygroundAppUITests/XCUIElementQueryPositionTests.swift
+++ b/PlaygroundAppUITests/XCUIElementQueryPositionTests.swift
@@ -1,0 +1,36 @@
+import XCUITestHelpers
+import XCTest
+
+class XCUIElementQueryPositionTests: XCTestCase {
+
+    let app = XCUIApplication()
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app.launch()
+    }
+
+    func testElementsShareCommonAxisX() {
+        let labelContains: (String) -> NSPredicate = { string in
+            return NSPredicate { object, _ in
+                // `XCUIElementAttributes` is the type of object received by the predicate at
+                // runtime as per the docs, but this `NSPredicate` syntax defines the input as
+                // `Any?` so we need to explicitly cast it.
+                guard let attributes = object as? XCUIElementAttributes else { return false }
+
+                return attributes.label.contains(string)
+            }
+        }
+
+        // We have a view with a 3x3 matrix with `Text` elements with content "xn-ym", where n is
+        // the index on the x axis and m the index on the y axis.
+        //
+        // All elements containing "xn-" should be on the same x axis
+        XCTAssertTrue(app.staticTexts.matching(labelContains("x1-")).allElementsShareCommonAxisX)
+        XCTAssertTrue(app.staticTexts.matching(labelContains("x2-")).allElementsShareCommonAxisX)
+        // All elements containing "-ym" should be on the same y axis, therefore not on the same x
+        // axis
+        XCTAssertFalse(app.staticTexts.matching(labelContains("-y1")).allElementsShareCommonAxisX)
+        XCTAssertFalse(app.staticTexts.matching(labelContains("-y2")).allElementsShareCommonAxisX)
+    }
+}

--- a/Sources/XCUITestHelpers/XCUIApplication+StatusBar.swift
+++ b/Sources/XCUITestHelpers/XCUIApplication+StatusBar.swift
@@ -1,0 +1,19 @@
+import XCTest
+
+extension XCUIApplication {
+
+    func tapStatusBar() {
+        let statusBar = statusBars.firstMatch
+
+        guard statusBar.exists else {
+            // If for some reason there's no status bar even thought the code expects one, use this
+            // workaround: tap the appropriate spot on the navigation bar.
+            return navigationBars
+                .allElementsBoundByIndex
+                .map { $0.coordinate(withNormalizedOffset: CGVector(dx: 20, dy: -20)) }
+                .forEach { $0.tap() }
+        }
+
+        statusBar.tap()
+    }
+}

--- a/Sources/XCUITestHelpers/XCUIApplication+StatusBar.swift
+++ b/Sources/XCUITestHelpers/XCUIApplication+StatusBar.swift
@@ -2,16 +2,26 @@ import XCTest
 
 extension XCUIApplication {
 
+    /// Helper function to hit the status bar that falls back to hitting the system's status bar
+    /// if the app has none.
     func tapStatusBar() {
         let statusBar = statusBars.firstMatch
 
         guard statusBar.exists else {
-            // If for some reason there's no status bar even thought the code expects one, use this
-            // workaround: tap the appropriate spot on the navigation bar.
-            return navigationBars
-                .allElementsBoundByIndex
-                .map { $0.coordinate(withNormalizedOffset: CGVector(dx: 20, dy: -20)) }
-                .forEach { $0.tap() }
+            // As of iOS 13.0, the status bar is part of Springboard, not the app itself. As such,
+            // we need to tap it from Springboard.
+            //
+            // This framework targets iOS 13 and above. So we don't need a fallback for previous
+            // versions.
+            //
+            // Credits https://alloc-init.com/blog/2019.08.08
+            let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+
+            // Springboard might return more than one status bar here (?!), so let's iterate on the
+            // results till we find one that can be hit.
+            springboard.statusBars.allElementsBoundByIndex.filter { $0.isHittable }.first?.tap()
+
+            return
         }
 
         statusBar.tap()

--- a/Sources/XCUITestHelpers/XCUIDevice+UserInterfaceIdiom.swift
+++ b/Sources/XCUITestHelpers/XCUIDevice+UserInterfaceIdiom.swift
@@ -1,0 +1,17 @@
+import UIKit
+import XCTest
+
+public extension XCUIDevice {
+
+    static var userInterfaceIdiom: UIUserInterfaceIdiom {
+        UIDevice.current.userInterfaceIdiom
+    }
+
+    static var isPhone: Bool {
+        userInterfaceIdiom == .phone
+    }
+
+    static var isPad: Bool {
+        userInterfaceIdiom == .pad
+    }
+}

--- a/Sources/XCUITestHelpers/XCUIDevice+UserInterfaceIdiom.swift
+++ b/Sources/XCUITestHelpers/XCUIDevice+UserInterfaceIdiom.swift
@@ -3,14 +3,29 @@ import XCTest
 
 public extension XCUIDevice {
 
+    /// The device `UIUserInterfaceIdiom`.
+    ///
+    /// This is declared as `static` rather than at the instance level to make it easier to call.
+    /// The UI tests thread can't run on multiple devices at the same time, so there is no strict
+    /// need to read this value from an instance.
     static var userInterfaceIdiom: UIUserInterfaceIdiom {
         UIDevice.current.userInterfaceIdiom
     }
 
+    /// Whether the device is an iPhone or an iPhone Simulator.
+    ///
+    /// This is declared as `static` rather than at the instance level to make it easier to call.
+    /// The UI tests thread can't run on multiple devices at the same time, so there is no strict
+    /// need to read this value from an instance.
     static var isPhone: Bool {
         userInterfaceIdiom == .phone
     }
 
+    /// Whether the device is an iPad or an iPad Simulator.
+    ///
+    /// This is declared as `static` rather than at the instance level to make it easier to call.
+    /// The UI tests thread can't run on multiple devices at the same time, so there is no strict
+    /// need to read this value from an instance.
     static var isPad: Bool {
         userInterfaceIdiom == .pad
     }

--- a/Sources/XCUITestHelpers/XCUIElement+Async.swift
+++ b/Sources/XCUITestHelpers/XCUIElement+Async.swift
@@ -1,0 +1,21 @@
+import XCTest
+
+extension XCUIElement {
+
+    /// Beware that this uses `XCTNSPredicateExpectation` which relies on polling and is slower than
+    /// other asynchronous expectations.
+    @discardableResult
+    public func waitForIsHittable(timeout: TimeInterval = 3.0) -> Bool {
+        let result = XCTWaiter.wait(
+            for: [
+                XCTNSPredicateExpectation(
+                    predicate: NSPredicate(format: "isHittable == true"),
+                    object: self
+                )
+            ],
+            timeout: timeout
+        )
+
+        return result == .completed
+    }
+}

--- a/Sources/XCUITestHelpers/XCUIElement+Async.swift
+++ b/Sources/XCUITestHelpers/XCUIElement+Async.swift
@@ -2,10 +2,16 @@ import XCTest
 
 extension XCUIElement {
 
-    /// Beware that this uses `XCTNSPredicateExpectation` which relies on polling and is slower than
-    /// other asynchronous expectations.
+    /// Waits for `self` to be hittable (for `isHittable` to be `true`) for the given `timeout`,
+    /// returning `true` if the wait was successful and `false` otherwise
+    ///
+    /// Beware that this uses `XCTNSPredicateExpectation` which relies on polling and is slower
+    /// that other asynchronous expectations.
     @discardableResult
     public func waitForIsHittable(timeout: TimeInterval = 3.0) -> Bool {
+        // Avoid unnecessary waiting if the element is already hittable
+        guard isHittable == false else { return true }
+
         let result = XCTWaiter.wait(
             for: [
                 XCTNSPredicateExpectation(

--- a/Sources/XCUITestHelpers/XCUIElementQuery+Position.swift
+++ b/Sources/XCUITestHelpers/XCUIElementQuery+Position.swift
@@ -2,6 +2,7 @@ import XCTest
 
 extension XCUIElementQuery {
 
+    /// Whether all elements in the query are aligned over the x axis.
     public var allElementsShareCommonAxisX: Bool {
         let elementsXPositions = allElementsBoundByIndex.map { $0.frame.minX }
 

--- a/Sources/XCUITestHelpers/XCUIElementQuery+Position.swift
+++ b/Sources/XCUITestHelpers/XCUIElementQuery+Position.swift
@@ -1,0 +1,11 @@
+import XCTest
+
+extension XCUIElementQuery {
+
+    public var allElementsShareCommonAxisX: Bool {
+        let elementsXPositions = allElementsBoundByIndex.map { $0.frame.minX }
+
+        // Use a set to remove duplicates – if all elements are the same, only one should remain.
+        return Set(elementsXPositions).count == 1
+    }
+}

--- a/XCUITestHelpers.xcodeproj/project.pbxproj
+++ b/XCUITestHelpers.xcodeproj/project.pbxproj
@@ -7,9 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3F1CA82126C3E7A300228BF2 /* XCUIDevice+UserInterfaceIdiom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1CA82026C3E7A300228BF2 /* XCUIDevice+UserInterfaceIdiom.swift */; };
 		3F762E8B26777BAF0088CD45 /* XCUITestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F762E8926777BAF0088CD45 /* XCUITestHelpers.swift */; };
 		3F762E8C26777BAF0088CD45 /* XCUITestHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F762E8A26777BAF0088CD45 /* XCUITestHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3F8CDAD926C2261F00A4A814 /* XCUIDevice+UserInterfaceStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8CDAD826C2261F00A4A814 /* XCUIDevice+UserInterfaceStyleTests.swift */; };
+		3F95FF4226C534A8007731D3 /* XCUIDeviceUserInterfaceIdiomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F95FF4126C534A8007731D3 /* XCUIDeviceUserInterfaceIdiomTests.swift */; };
 		3FDF285326C1EC5E0027CF19 /* XCUIDevice+UserInterfaceStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FDF285226C1EC5E0027CF19 /* XCUIDevice+UserInterfaceStyle.swift */; };
 		3FF1424F266DB46C00138163 /* XCUITestHelpers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FF1423C266DB44900138163 /* XCUITestHelpers.framework */; };
 		3FF14261266DB7AB00138163 /* XCUITestHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF1425F266DB7AB00138163 /* XCUITestHelpersTests.swift */; };
@@ -46,9 +48,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3F1CA82026C3E7A300228BF2 /* XCUIDevice+UserInterfaceIdiom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIDevice+UserInterfaceIdiom.swift"; sourceTree = "<group>"; };
 		3F762E8926777BAF0088CD45 /* XCUITestHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCUITestHelpers.swift; sourceTree = "<group>"; };
 		3F762E8A26777BAF0088CD45 /* XCUITestHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XCUITestHelpers.h; sourceTree = "<group>"; };
 		3F8CDAD826C2261F00A4A814 /* XCUIDevice+UserInterfaceStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIDevice+UserInterfaceStyleTests.swift"; sourceTree = "<group>"; };
+		3F95FF4126C534A8007731D3 /* XCUIDeviceUserInterfaceIdiomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCUIDeviceUserInterfaceIdiomTests.swift; sourceTree = "<group>"; };
 		3FDF285226C1EC5E0027CF19 /* XCUIDevice+UserInterfaceStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIDevice+UserInterfaceStyle.swift"; sourceTree = "<group>"; };
 		3FF1423C266DB44900138163 /* XCUITestHelpers.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = XCUITestHelpers.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3FF14240266DB44900138163 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -136,6 +140,7 @@
 			children = (
 				3FF14240266DB44900138163 /* Info.plist */,
 				3FF142C1266DBA3500138163 /* XCUIApplication+Device.swift */,
+				3F1CA82026C3E7A300228BF2 /* XCUIDevice+UserInterfaceIdiom.swift */,
 				3FDF285226C1EC5E0027CF19 /* XCUIDevice+UserInterfaceStyle.swift */,
 				3FF142C2266DBA3500138163 /* XCUIElement+TextManagement.swift */,
 				3FF142C3266DBA3500138163 /* XCUIElementQuery+Sequence.swift */,
@@ -185,6 +190,7 @@
 				3FF1429B266DB85500138163 /* Info.plist */,
 				3FF14299266DB85500138163 /* PlaygroundAppUITests.swift */,
 				3F8CDAD826C2261F00A4A814 /* XCUIDevice+UserInterfaceStyleTests.swift */,
+				3F95FF4126C534A8007731D3 /* XCUIDeviceUserInterfaceIdiomTests.swift */,
 			);
 			path = PlaygroundAppUITests;
 			sourceTree = "<group>";
@@ -368,6 +374,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3F1CA82126C3E7A300228BF2 /* XCUIDevice+UserInterfaceIdiom.swift in Sources */,
 				3FDF285326C1EC5E0027CF19 /* XCUIDevice+UserInterfaceStyle.swift in Sources */,
 				3F762E8B26777BAF0088CD45 /* XCUITestHelpers.swift in Sources */,
 				3FF142C5266DBA3500138163 /* XCUIElement+TextManagement.swift in Sources */,
@@ -401,6 +408,7 @@
 			files = (
 				3F8CDAD926C2261F00A4A814 /* XCUIDevice+UserInterfaceStyleTests.swift in Sources */,
 				3FF1429A266DB85500138163 /* PlaygroundAppUITests.swift in Sources */,
+				3F95FF4226C534A8007731D3 /* XCUIDeviceUserInterfaceIdiomTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XCUITestHelpers.xcodeproj/project.pbxproj
+++ b/XCUITestHelpers.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		3F762E8C26777BAF0088CD45 /* XCUITestHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F762E8A26777BAF0088CD45 /* XCUITestHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3F8CDAD926C2261F00A4A814 /* XCUIDevice+UserInterfaceStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8CDAD826C2261F00A4A814 /* XCUIDevice+UserInterfaceStyleTests.swift */; };
 		3F95FF4226C534A8007731D3 /* XCUIDeviceUserInterfaceIdiomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F95FF4126C534A8007731D3 /* XCUIDeviceUserInterfaceIdiomTests.swift */; };
+		3F95FF4426C53A15007731D3 /* XCUIApplication+StatusBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F95FF4326C53A15007731D3 /* XCUIApplication+StatusBar.swift */; };
 		3FDF285326C1EC5E0027CF19 /* XCUIDevice+UserInterfaceStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FDF285226C1EC5E0027CF19 /* XCUIDevice+UserInterfaceStyle.swift */; };
 		3FF1424F266DB46C00138163 /* XCUITestHelpers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FF1423C266DB44900138163 /* XCUITestHelpers.framework */; };
 		3FF14261266DB7AB00138163 /* XCUITestHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF1425F266DB7AB00138163 /* XCUITestHelpersTests.swift */; };
@@ -53,6 +54,7 @@
 		3F762E8A26777BAF0088CD45 /* XCUITestHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XCUITestHelpers.h; sourceTree = "<group>"; };
 		3F8CDAD826C2261F00A4A814 /* XCUIDevice+UserInterfaceStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIDevice+UserInterfaceStyleTests.swift"; sourceTree = "<group>"; };
 		3F95FF4126C534A8007731D3 /* XCUIDeviceUserInterfaceIdiomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCUIDeviceUserInterfaceIdiomTests.swift; sourceTree = "<group>"; };
+		3F95FF4326C53A15007731D3 /* XCUIApplication+StatusBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIApplication+StatusBar.swift"; sourceTree = "<group>"; };
 		3FDF285226C1EC5E0027CF19 /* XCUIDevice+UserInterfaceStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIDevice+UserInterfaceStyle.swift"; sourceTree = "<group>"; };
 		3FF1423C266DB44900138163 /* XCUITestHelpers.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = XCUITestHelpers.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3FF14240266DB44900138163 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -143,6 +145,7 @@
 				3F1CA82026C3E7A300228BF2 /* XCUIDevice+UserInterfaceIdiom.swift */,
 				3FDF285226C1EC5E0027CF19 /* XCUIDevice+UserInterfaceStyle.swift */,
 				3FF142C2266DBA3500138163 /* XCUIElement+TextManagement.swift */,
+				3F95FF4326C53A15007731D3 /* XCUIApplication+StatusBar.swift */,
 				3FF142C3266DBA3500138163 /* XCUIElementQuery+Sequence.swift */,
 				3F762E8A26777BAF0088CD45 /* XCUITestHelpers.h */,
 				3F762E8926777BAF0088CD45 /* XCUITestHelpers.swift */,
@@ -407,6 +410,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3F8CDAD926C2261F00A4A814 /* XCUIDevice+UserInterfaceStyleTests.swift in Sources */,
+				3F95FF4426C53A15007731D3 /* XCUIApplication+StatusBar.swift in Sources */,
 				3FF1429A266DB85500138163 /* PlaygroundAppUITests.swift in Sources */,
 				3F95FF4226C534A8007731D3 /* XCUIDeviceUserInterfaceIdiomTests.swift in Sources */,
 			);

--- a/XCUITestHelpers.xcodeproj/project.pbxproj
+++ b/XCUITestHelpers.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		3F8CDAD926C2261F00A4A814 /* XCUIDevice+UserInterfaceStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8CDAD826C2261F00A4A814 /* XCUIDevice+UserInterfaceStyleTests.swift */; };
 		3F95FF4226C534A8007731D3 /* XCUIDeviceUserInterfaceIdiomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F95FF4126C534A8007731D3 /* XCUIDeviceUserInterfaceIdiomTests.swift */; };
 		3F95FF4426C53A15007731D3 /* XCUIApplication+StatusBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F95FF4326C53A15007731D3 /* XCUIApplication+StatusBar.swift */; };
+		3F95FF4626C53E0D007731D3 /* XCUIElement+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F95FF4526C53E0D007731D3 /* XCUIElement+Async.swift */; };
 		3FDF285326C1EC5E0027CF19 /* XCUIDevice+UserInterfaceStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FDF285226C1EC5E0027CF19 /* XCUIDevice+UserInterfaceStyle.swift */; };
 		3FF1424F266DB46C00138163 /* XCUITestHelpers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FF1423C266DB44900138163 /* XCUITestHelpers.framework */; };
 		3FF14261266DB7AB00138163 /* XCUITestHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF1425F266DB7AB00138163 /* XCUITestHelpersTests.swift */; };
@@ -55,6 +56,7 @@
 		3F8CDAD826C2261F00A4A814 /* XCUIDevice+UserInterfaceStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIDevice+UserInterfaceStyleTests.swift"; sourceTree = "<group>"; };
 		3F95FF4126C534A8007731D3 /* XCUIDeviceUserInterfaceIdiomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCUIDeviceUserInterfaceIdiomTests.swift; sourceTree = "<group>"; };
 		3F95FF4326C53A15007731D3 /* XCUIApplication+StatusBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIApplication+StatusBar.swift"; sourceTree = "<group>"; };
+		3F95FF4526C53E0D007731D3 /* XCUIElement+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIElement+Async.swift"; sourceTree = "<group>"; };
 		3FDF285226C1EC5E0027CF19 /* XCUIDevice+UserInterfaceStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIDevice+UserInterfaceStyle.swift"; sourceTree = "<group>"; };
 		3FF1423C266DB44900138163 /* XCUITestHelpers.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = XCUITestHelpers.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3FF14240266DB44900138163 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -142,10 +144,11 @@
 			children = (
 				3FF14240266DB44900138163 /* Info.plist */,
 				3FF142C1266DBA3500138163 /* XCUIApplication+Device.swift */,
+				3F95FF4326C53A15007731D3 /* XCUIApplication+StatusBar.swift */,
 				3F1CA82026C3E7A300228BF2 /* XCUIDevice+UserInterfaceIdiom.swift */,
 				3FDF285226C1EC5E0027CF19 /* XCUIDevice+UserInterfaceStyle.swift */,
+				3F95FF4526C53E0D007731D3 /* XCUIElement+Async.swift */,
 				3FF142C2266DBA3500138163 /* XCUIElement+TextManagement.swift */,
-				3F95FF4326C53A15007731D3 /* XCUIApplication+StatusBar.swift */,
 				3FF142C3266DBA3500138163 /* XCUIElementQuery+Sequence.swift */,
 				3F762E8A26777BAF0088CD45 /* XCUITestHelpers.h */,
 				3F762E8926777BAF0088CD45 /* XCUITestHelpers.swift */,
@@ -411,6 +414,7 @@
 			files = (
 				3F8CDAD926C2261F00A4A814 /* XCUIDevice+UserInterfaceStyleTests.swift in Sources */,
 				3F95FF4426C53A15007731D3 /* XCUIApplication+StatusBar.swift in Sources */,
+				3F95FF4626C53E0D007731D3 /* XCUIElement+Async.swift in Sources */,
 				3FF1429A266DB85500138163 /* PlaygroundAppUITests.swift in Sources */,
 				3F95FF4226C534A8007731D3 /* XCUIDeviceUserInterfaceIdiomTests.swift in Sources */,
 			);

--- a/XCUITestHelpers.xcodeproj/project.pbxproj
+++ b/XCUITestHelpers.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		3F1C9AE226CC9C9300101E82 /* XCUIApplication+StatusBarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1C9AE126CC9C9300101E82 /* XCUIApplication+StatusBarTests.swift */; };
 		3F1C9AE326CC9E0E00101E82 /* XCUIElementQuery+Position.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F95FF4726C5425A007731D3 /* XCUIElementQuery+Position.swift */; };
+		3F1C9AE526CCA4B300101E82 /* XCUIElementQueryPositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1C9AE426CCA4B300101E82 /* XCUIElementQueryPositionTests.swift */; };
 		3F1CA82126C3E7A300228BF2 /* XCUIDevice+UserInterfaceIdiom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1CA82026C3E7A300228BF2 /* XCUIDevice+UserInterfaceIdiom.swift */; };
 		3F762E8B26777BAF0088CD45 /* XCUITestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F762E8926777BAF0088CD45 /* XCUITestHelpers.swift */; };
 		3F762E8C26777BAF0088CD45 /* XCUITestHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F762E8A26777BAF0088CD45 /* XCUITestHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -53,6 +54,7 @@
 
 /* Begin PBXFileReference section */
 		3F1C9AE126CC9C9300101E82 /* XCUIApplication+StatusBarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIApplication+StatusBarTests.swift"; sourceTree = "<group>"; };
+		3F1C9AE426CCA4B300101E82 /* XCUIElementQueryPositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCUIElementQueryPositionTests.swift; sourceTree = "<group>"; };
 		3F1CA82026C3E7A300228BF2 /* XCUIDevice+UserInterfaceIdiom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIDevice+UserInterfaceIdiom.swift"; sourceTree = "<group>"; };
 		3F762E8926777BAF0088CD45 /* XCUITestHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCUITestHelpers.swift; sourceTree = "<group>"; };
 		3F762E8A26777BAF0088CD45 /* XCUITestHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XCUITestHelpers.h; sourceTree = "<group>"; };
@@ -203,6 +205,7 @@
 				3F1C9AE126CC9C9300101E82 /* XCUIApplication+StatusBarTests.swift */,
 				3F8CDAD826C2261F00A4A814 /* XCUIDevice+UserInterfaceStyleTests.swift */,
 				3F95FF4126C534A8007731D3 /* XCUIDeviceUserInterfaceIdiomTests.swift */,
+				3F1C9AE426CCA4B300101E82 /* XCUIElementQueryPositionTests.swift */,
 			);
 			path = PlaygroundAppUITests;
 			sourceTree = "<group>";
@@ -420,6 +423,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3F8CDAD926C2261F00A4A814 /* XCUIDevice+UserInterfaceStyleTests.swift in Sources */,
+				3F1C9AE526CCA4B300101E82 /* XCUIElementQueryPositionTests.swift in Sources */,
 				3F95FF4426C53A15007731D3 /* XCUIApplication+StatusBar.swift in Sources */,
 				3F95FF4626C53E0D007731D3 /* XCUIElement+Async.swift in Sources */,
 				3FF1429A266DB85500138163 /* PlaygroundAppUITests.swift in Sources */,

--- a/XCUITestHelpers.xcodeproj/project.pbxproj
+++ b/XCUITestHelpers.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		3F1C9AE226CC9C9300101E82 /* XCUIApplication+StatusBarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1C9AE126CC9C9300101E82 /* XCUIApplication+StatusBarTests.swift */; };
+		3F1C9AE326CC9E0E00101E82 /* XCUIElementQuery+Position.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F95FF4726C5425A007731D3 /* XCUIElementQuery+Position.swift */; };
 		3F1CA82126C3E7A300228BF2 /* XCUIDevice+UserInterfaceIdiom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1CA82026C3E7A300228BF2 /* XCUIDevice+UserInterfaceIdiom.swift */; };
 		3F762E8B26777BAF0088CD45 /* XCUITestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F762E8926777BAF0088CD45 /* XCUITestHelpers.swift */; };
 		3F762E8C26777BAF0088CD45 /* XCUITestHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F762E8A26777BAF0088CD45 /* XCUITestHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -15,7 +16,6 @@
 		3F95FF4226C534A8007731D3 /* XCUIDeviceUserInterfaceIdiomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F95FF4126C534A8007731D3 /* XCUIDeviceUserInterfaceIdiomTests.swift */; };
 		3F95FF4426C53A15007731D3 /* XCUIApplication+StatusBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F95FF4326C53A15007731D3 /* XCUIApplication+StatusBar.swift */; };
 		3F95FF4626C53E0D007731D3 /* XCUIElement+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F95FF4526C53E0D007731D3 /* XCUIElement+Async.swift */; };
-		3F95FF4826C5425A007731D3 /* XCUIElementQuery+Position.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F95FF4726C5425A007731D3 /* XCUIElementQuery+Position.swift */; };
 		3FDF285326C1EC5E0027CF19 /* XCUIDevice+UserInterfaceStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FDF285226C1EC5E0027CF19 /* XCUIDevice+UserInterfaceStyle.swift */; };
 		3FF1424F266DB46C00138163 /* XCUITestHelpers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FF1423C266DB44900138163 /* XCUITestHelpers.framework */; };
 		3FF14261266DB7AB00138163 /* XCUITestHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF1425F266DB7AB00138163 /* XCUITestHelpersTests.swift */; };
@@ -387,6 +387,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3F1CA82126C3E7A300228BF2 /* XCUIDevice+UserInterfaceIdiom.swift in Sources */,
+				3F1C9AE326CC9E0E00101E82 /* XCUIElementQuery+Position.swift in Sources */,
 				3FDF285326C1EC5E0027CF19 /* XCUIDevice+UserInterfaceStyle.swift in Sources */,
 				3F762E8B26777BAF0088CD45 /* XCUITestHelpers.swift in Sources */,
 				3FF142C5266DBA3500138163 /* XCUIElement+TextManagement.swift in Sources */,
@@ -421,7 +422,6 @@
 				3F8CDAD926C2261F00A4A814 /* XCUIDevice+UserInterfaceStyleTests.swift in Sources */,
 				3F95FF4426C53A15007731D3 /* XCUIApplication+StatusBar.swift in Sources */,
 				3F95FF4626C53E0D007731D3 /* XCUIElement+Async.swift in Sources */,
-				3F95FF4826C5425A007731D3 /* XCUIElementQuery+Position.swift in Sources */,
 				3FF1429A266DB85500138163 /* PlaygroundAppUITests.swift in Sources */,
 				3F1C9AE226CC9C9300101E82 /* XCUIApplication+StatusBarTests.swift in Sources */,
 				3F95FF4226C534A8007731D3 /* XCUIDeviceUserInterfaceIdiomTests.swift in Sources */,

--- a/XCUITestHelpers.xcodeproj/project.pbxproj
+++ b/XCUITestHelpers.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		3F95FF4226C534A8007731D3 /* XCUIDeviceUserInterfaceIdiomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F95FF4126C534A8007731D3 /* XCUIDeviceUserInterfaceIdiomTests.swift */; };
 		3F95FF4426C53A15007731D3 /* XCUIApplication+StatusBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F95FF4326C53A15007731D3 /* XCUIApplication+StatusBar.swift */; };
 		3F95FF4626C53E0D007731D3 /* XCUIElement+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F95FF4526C53E0D007731D3 /* XCUIElement+Async.swift */; };
+		3F95FF4826C5425A007731D3 /* XCUIElementQuery+Position.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F95FF4726C5425A007731D3 /* XCUIElementQuery+Position.swift */; };
 		3FDF285326C1EC5E0027CF19 /* XCUIDevice+UserInterfaceStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FDF285226C1EC5E0027CF19 /* XCUIDevice+UserInterfaceStyle.swift */; };
 		3FF1424F266DB46C00138163 /* XCUITestHelpers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FF1423C266DB44900138163 /* XCUITestHelpers.framework */; };
 		3FF14261266DB7AB00138163 /* XCUITestHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF1425F266DB7AB00138163 /* XCUITestHelpersTests.swift */; };
@@ -57,6 +58,7 @@
 		3F95FF4126C534A8007731D3 /* XCUIDeviceUserInterfaceIdiomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCUIDeviceUserInterfaceIdiomTests.swift; sourceTree = "<group>"; };
 		3F95FF4326C53A15007731D3 /* XCUIApplication+StatusBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIApplication+StatusBar.swift"; sourceTree = "<group>"; };
 		3F95FF4526C53E0D007731D3 /* XCUIElement+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIElement+Async.swift"; sourceTree = "<group>"; };
+		3F95FF4726C5425A007731D3 /* XCUIElementQuery+Position.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIElementQuery+Position.swift"; sourceTree = "<group>"; };
 		3FDF285226C1EC5E0027CF19 /* XCUIDevice+UserInterfaceStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIDevice+UserInterfaceStyle.swift"; sourceTree = "<group>"; };
 		3FF1423C266DB44900138163 /* XCUITestHelpers.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = XCUITestHelpers.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3FF14240266DB44900138163 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -149,6 +151,7 @@
 				3FDF285226C1EC5E0027CF19 /* XCUIDevice+UserInterfaceStyle.swift */,
 				3F95FF4526C53E0D007731D3 /* XCUIElement+Async.swift */,
 				3FF142C2266DBA3500138163 /* XCUIElement+TextManagement.swift */,
+				3F95FF4726C5425A007731D3 /* XCUIElementQuery+Position.swift */,
 				3FF142C3266DBA3500138163 /* XCUIElementQuery+Sequence.swift */,
 				3F762E8A26777BAF0088CD45 /* XCUITestHelpers.h */,
 				3F762E8926777BAF0088CD45 /* XCUITestHelpers.swift */,
@@ -415,6 +418,7 @@
 				3F8CDAD926C2261F00A4A814 /* XCUIDevice+UserInterfaceStyleTests.swift in Sources */,
 				3F95FF4426C53A15007731D3 /* XCUIApplication+StatusBar.swift in Sources */,
 				3F95FF4626C53E0D007731D3 /* XCUIElement+Async.swift in Sources */,
+				3F95FF4826C5425A007731D3 /* XCUIElementQuery+Position.swift in Sources */,
 				3FF1429A266DB85500138163 /* PlaygroundAppUITests.swift in Sources */,
 				3F95FF4226C534A8007731D3 /* XCUIDeviceUserInterfaceIdiomTests.swift in Sources */,
 			);

--- a/XCUITestHelpers.xcodeproj/project.pbxproj
+++ b/XCUITestHelpers.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3F1C9AE226CC9C9300101E82 /* XCUIApplication+StatusBarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1C9AE126CC9C9300101E82 /* XCUIApplication+StatusBarTests.swift */; };
 		3F1CA82126C3E7A300228BF2 /* XCUIDevice+UserInterfaceIdiom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1CA82026C3E7A300228BF2 /* XCUIDevice+UserInterfaceIdiom.swift */; };
 		3F762E8B26777BAF0088CD45 /* XCUITestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F762E8926777BAF0088CD45 /* XCUITestHelpers.swift */; };
 		3F762E8C26777BAF0088CD45 /* XCUITestHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F762E8A26777BAF0088CD45 /* XCUITestHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -51,6 +52,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3F1C9AE126CC9C9300101E82 /* XCUIApplication+StatusBarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIApplication+StatusBarTests.swift"; sourceTree = "<group>"; };
 		3F1CA82026C3E7A300228BF2 /* XCUIDevice+UserInterfaceIdiom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIDevice+UserInterfaceIdiom.swift"; sourceTree = "<group>"; };
 		3F762E8926777BAF0088CD45 /* XCUITestHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCUITestHelpers.swift; sourceTree = "<group>"; };
 		3F762E8A26777BAF0088CD45 /* XCUITestHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XCUITestHelpers.h; sourceTree = "<group>"; };
@@ -198,6 +200,7 @@
 			children = (
 				3FF1429B266DB85500138163 /* Info.plist */,
 				3FF14299266DB85500138163 /* PlaygroundAppUITests.swift */,
+				3F1C9AE126CC9C9300101E82 /* XCUIApplication+StatusBarTests.swift */,
 				3F8CDAD826C2261F00A4A814 /* XCUIDevice+UserInterfaceStyleTests.swift */,
 				3F95FF4126C534A8007731D3 /* XCUIDeviceUserInterfaceIdiomTests.swift */,
 			);
@@ -420,6 +423,7 @@
 				3F95FF4626C53E0D007731D3 /* XCUIElement+Async.swift in Sources */,
 				3F95FF4826C5425A007731D3 /* XCUIElementQuery+Position.swift in Sources */,
 				3FF1429A266DB85500138163 /* PlaygroundAppUITests.swift in Sources */,
+				3F1C9AE226CC9C9300101E82 /* XCUIApplication+StatusBarTests.swift in Sources */,
 				3F95FF4226C534A8007731D3 /* XCUIDeviceUserInterfaceIdiomTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/XCUITestHelpers.xcodeproj/xcshareddata/xcschemes/PlaygroundApp.xcscheme
+++ b/XCUITestHelpers.xcodeproj/xcshareddata/xcschemes/PlaygroundApp.xcscheme
@@ -26,7 +26,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3FF1423B266DB44900138163"
+            BuildableName = "XCUITestHelpers.framework"
+            BlueprintName = "XCUITestHelpers"
+            ReferencedContainer = "container:XCUITestHelpers.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/XCUITestHelpers.xcodeproj/xcshareddata/xcschemes/XCUITestHelpers.xcscheme
+++ b/XCUITestHelpers.xcodeproj/xcshareddata/xcschemes/XCUITestHelpers.xcscheme
@@ -26,7 +26,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3FF1423B266DB44900138163"
+            BuildableName = "XCUITestHelpers.framework"
+            BlueprintName = "XCUITestHelpers"
+            ReferencedContainer = "container:XCUITestHelpers.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -35,6 +46,16 @@
                BlueprintIdentifier = "3FF14249266DB46C00138163"
                BuildableName = "XCUITestHelpersTests.xctest"
                BlueprintName = "XCUITestHelpersTests"
+               ReferencedContainer = "container:XCUITestHelpers.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3FF14294266DB85500138163"
+               BuildableName = "PlaygroundAppUITests.xctest"
+               BlueprintName = "PlaygroundAppUITests"
                ReferencedContainer = "container:XCUITestHelpers.xcodeproj">
             </BuildableReference>
          </TestableReference>


### PR DESCRIPTION
See https://github.com/woocommerce/woocommerce-ios/pull/4811.

Adds:

- `XCUIDevice` extension to query the device type (iPhone vs iPad)
- `XCUIApplication` extension with method to tap the status bar
- `XCUIElement` extension with method to wait for `isHittable` to become `true`
- `XCUIElementQuery` extension to verify all elements are vertically aligned (share the same min x coordinate)

To verify all these utilities in isolation, I had to add a bunch of UI tests and modify the UI of the test application, which is why the diff is so big.

To test, you'll have to checkout the branch and run the UI tests yourself (`Cmd U` from either target will do that). I plan to add CI integration in another PR.

I run the UI tests on the iPhone 12 and iPod touch 7th gen Simulators.