### PR TITLE
Configure CI via Buildkite

### DIFF
--- a/.buildkite/commands/run-tests.sh
+++ b/.buildkite/commands/run-tests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -eu
+
+SIMULATOR_NAME=$1
+
+xcodebuild clean test \
+  -project 'XCUITestHelpers.xcodeproj' \
+  -scheme 'XCUITestHelpers' \
+  -destination "platform=iOS Simulator,name=$SIMULATOR_NAME,OS=14.5"

--- a/.buildkite/commands/run-tests.sh
+++ b/.buildkite/commands/run-tests.sh
@@ -19,4 +19,5 @@ SIMULATOR_VERSION='14.5'
 xcodebuild clean test \
   -project 'XCUITestHelpers.xcodeproj' \
   -scheme 'XCUITestHelpers' \
-  -destination "platform=iOS Simulator,name=$SIMULATOR_NAME,OS=$SIMULATOR_VERSION"
+  -destination "platform=iOS Simulator,name=$SIMULATOR_NAME,OS=$SIMULATOR_VERSION" \
+  -quiet

--- a/.buildkite/commands/run-tests.sh
+++ b/.buildkite/commands/run-tests.sh
@@ -4,18 +4,19 @@
 #
 # - We are using raw `xcodebuild` without extra tooling such as Fastlane,
 #   `xcpretty`, or `xcbeautify`. This is an intentional compromise to keep the
-#   setup lean, as adding any of those would require extras in CI such as
-#   chating for what, right now, looks like merely a log readability gain.
+#   setup lean, as adding any of those would require extra tooling and
+#   ceremony in CI for what, right now, is merely a gain in log readability.
 #
-# - The iOS Simulator version is hardcoded in the command call, unlike the
-#   Simulator device, so we have a single source of truth. The downside is that
-#   the syntax in the pipeline is less clear: a reader might as where's the
-#   iOS version set. As long as we only need to test against the latest iOS
+# - The iOS Simulator version is hardcoded in the script, unlike the Simulator
+#   device, so we have a single source of truth. The downside is that the
+#   syntax in the pipeline is less clear: a reader might ask where the iOS
+#   version is set. As long as we only need to test against the latest iOS
 #   version, that seems like a reasonable tradeoff to make it easier to move to
 #   newer versions as they are released.
 SIMULATOR_NAME=$1
+SIMULATOR_VERSION='14.5'
 
 xcodebuild clean test \
   -project 'XCUITestHelpers.xcodeproj' \
   -scheme 'XCUITestHelpers' \
-  -destination "platform=iOS Simulator,name=$SIMULATOR_NAME,OS=14.5"
+  -destination "platform=iOS Simulator,name=$SIMULATOR_NAME,OS=$SIMULATOR_VERSION"

--- a/.buildkite/commands/run-tests.sh
+++ b/.buildkite/commands/run-tests.sh
@@ -1,5 +1,18 @@
 #!/bin/bash -eu
 
+# Notice that:
+#
+# - We are using raw `xcodebuild` without extra tooling such as Fastlane,
+#   `xcpretty`, or `xcbeautify`. This is an intentional compromise to keep the
+#   setup lean, as adding any of those would require extras in CI such as
+#   chating for what, right now, looks like merely a log readability gain.
+#
+# - The iOS Simulator version is hardcoded in the command call, unlike the
+#   Simulator device, so we have a single source of truth. The downside is that
+#   the syntax in the pipeline is less clear: a reader might as where's the
+#   iOS version set. As long as we only need to test against the latest iOS
+#   version, that seems like a reasonable tradeoff to make it easier to move to
+#   newer versions as they are released.
 SIMULATOR_NAME=$1
 
 xcodebuild clean test \

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,11 @@
+env:
+  IMAGE_ID: xcode-12.5.1
+agents:
+  queue: 'mac'
+
+steps:
+  - label: "🧪 Build and Test (iPhone 12 Simulator)"
+    command: .buildkite/commands/run-tests.sh 'iPhone 12'
+
+  - label: "🧪 Build and Test (iPad Pro (12.9-inch) (5th generation) Simulator)"
+    command: .buildkite/commands/run-tests.sh 'iPad Pro (12.9-inch) (5th generation)'


### PR DESCRIPTION
Integrates Buildkite to run the UI tests against iPhone 12 and latest iPad Pro
We may add more Simulator targets in the future, e.g. if we discover fiddly methods that behave differently across Simulator.

To test, verify that CI run and passed.

See also https://github.com/Automattic/ScreenObject/pull/6.