### PR TITLE
Add `isFullyVisibleOnScreen` helper on `XCUIElement`

### DIFF
--- a/PlaygroundAppUITests/XCUIElementQueryPositionTests.swift
+++ b/PlaygroundAppUITests/XCUIElementQueryPositionTests.swift
@@ -10,6 +10,15 @@ class XCUIElementQueryPositionTests: XCTestCase {
         app.launch()
     }
 
+    func testFullyVisible() {
+        // In the scroll view with the alphabet's letters, "a" is at the top and should be fully
+        // visible.
+        XCTAssertTrue(app.staticTexts["a"].isFullyVisibleOnScreen())
+        // In the scroll view with the alphabet's letters, "z" is at the bottom and should out of
+        // screen.
+        XCTAssertFalse(app.staticTexts["z"].isFullyVisibleOnScreen())
+    }
+
     func testElementsShareCommonAxisX() {
         let labelContains: (String) -> NSPredicate = { string in
             return NSPredicate { object, _ in

--- a/Sources/XCUITestHelpers/XCUIElement+Visibility.swift
+++ b/Sources/XCUITestHelpers/XCUIElement+Visibility.swift
@@ -1,0 +1,10 @@
+import XCTest
+
+public extension XCUIElement {
+
+    func isFullyVisibleOnScreen(in app: XCUIApplication = XCUIApplication()) -> Bool {
+        guard exists && frame.isEmpty == false && isHittable else { return false }
+
+        return app.windows.element(boundBy: 0).frame.contains(frame)
+    }
+}

--- a/XCUITestHelpers.xcodeproj/project.pbxproj
+++ b/XCUITestHelpers.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		3F1C9AE326CC9E0E00101E82 /* XCUIElementQuery+Position.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F95FF4726C5425A007731D3 /* XCUIElementQuery+Position.swift */; };
 		3F1C9AE526CCA4B300101E82 /* XCUIElementQueryPositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1C9AE426CCA4B300101E82 /* XCUIElementQueryPositionTests.swift */; };
 		3F1CA82126C3E7A300228BF2 /* XCUIDevice+UserInterfaceIdiom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1CA82026C3E7A300228BF2 /* XCUIDevice+UserInterfaceIdiom.swift */; };
+		3F4D7F94275E308000650353 /* XCUIElement+Visibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4D7F93275E308000650353 /* XCUIElement+Visibility.swift */; };
 		3F762E8B26777BAF0088CD45 /* XCUITestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F762E8926777BAF0088CD45 /* XCUITestHelpers.swift */; };
 		3F762E8C26777BAF0088CD45 /* XCUITestHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F762E8A26777BAF0088CD45 /* XCUITestHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3F8CDAD926C2261F00A4A814 /* XCUIDevice+UserInterfaceStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8CDAD826C2261F00A4A814 /* XCUIDevice+UserInterfaceStyleTests.swift */; };
@@ -56,6 +57,7 @@
 		3F1C9AE126CC9C9300101E82 /* XCUIApplication+StatusBarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIApplication+StatusBarTests.swift"; sourceTree = "<group>"; };
 		3F1C9AE426CCA4B300101E82 /* XCUIElementQueryPositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCUIElementQueryPositionTests.swift; sourceTree = "<group>"; };
 		3F1CA82026C3E7A300228BF2 /* XCUIDevice+UserInterfaceIdiom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIDevice+UserInterfaceIdiom.swift"; sourceTree = "<group>"; };
+		3F4D7F93275E308000650353 /* XCUIElement+Visibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIElement+Visibility.swift"; sourceTree = "<group>"; };
 		3F762E8926777BAF0088CD45 /* XCUITestHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCUITestHelpers.swift; sourceTree = "<group>"; };
 		3F762E8A26777BAF0088CD45 /* XCUITestHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XCUITestHelpers.h; sourceTree = "<group>"; };
 		3F8CDAD826C2261F00A4A814 /* XCUIDevice+UserInterfaceStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIDevice+UserInterfaceStyleTests.swift"; sourceTree = "<group>"; };
@@ -155,6 +157,7 @@
 				3FDF285226C1EC5E0027CF19 /* XCUIDevice+UserInterfaceStyle.swift */,
 				3F95FF4526C53E0D007731D3 /* XCUIElement+Async.swift */,
 				3FF142C2266DBA3500138163 /* XCUIElement+TextManagement.swift */,
+				3F4D7F93275E308000650353 /* XCUIElement+Visibility.swift */,
 				3F95FF4726C5425A007731D3 /* XCUIElementQuery+Position.swift */,
 				3FF142C3266DBA3500138163 /* XCUIElementQuery+Sequence.swift */,
 				3F762E8A26777BAF0088CD45 /* XCUITestHelpers.h */,
@@ -394,6 +397,7 @@
 				3FDF285326C1EC5E0027CF19 /* XCUIDevice+UserInterfaceStyle.swift in Sources */,
 				3F762E8B26777BAF0088CD45 /* XCUITestHelpers.swift in Sources */,
 				3FF142C5266DBA3500138163 /* XCUIElement+TextManagement.swift in Sources */,
+				3F4D7F94275E308000650353 /* XCUIElement+Visibility.swift in Sources */,
 				3FF142C4266DBA3500138163 /* XCUIApplication+Device.swift in Sources */,
 				3FF142C6266DBA3500138163 /* XCUIElementQuery+Sequence.swift in Sources */,
 			);


### PR DESCRIPTION
Extracts an helper used in a few places in the WordPress iOS app into the framework.

You can see it in action in WordPress iOS [here](https://github.com/wordpress-mobile/WordPress-iOS/pull/17628). I won't be making a similar PR in WooCommerce because all the method's usages there are in deprecated code.