### PR TITLE
Add `XCUIElement` helper methods to wait for an `NSPredicate`

### DIFF
--- a/PlaygroundAppUITests/XCTWaiter.Result+CustomStringConvertible.swift
+++ b/PlaygroundAppUITests/XCTWaiter.Result+CustomStringConvertible.swift
@@ -1,0 +1,15 @@
+import XCTest
+
+extension XCTWaiter.Result: CustomStringConvertible {
+
+    public var description: String {
+        switch self {
+        case .completed: return "XCTWaiter.Result .completed"
+        case .incorrectOrder: return "XCTWaiter.Result .incorrectOrder"
+        case .interrupted: return "XCTWaiter.Result .interruted"
+        case .invertedFulfillment: return "XCTWaiter.Result .invertedFulfillment"
+        case .timedOut: return "XCTWaiter.Result .timedOut"
+        @unknown default: return "XCTWaiter.Result unknown case – Please file a bug report at https://github.com/Automattic/XCUITestHelpers"
+        }
+    }
+}

--- a/PlaygroundAppUITests/XCUIElement+AsyncTests.swift
+++ b/PlaygroundAppUITests/XCUIElement+AsyncTests.swift
@@ -1,0 +1,8 @@
+//
+//  XCUIElement+AsyncTests.swift
+//  PlaygroundAppUITests
+//
+//  Created by Gio on 9/12/21.
+//
+
+import Foundation

--- a/PlaygroundAppUITests/XCUIElement+AsyncTests.swift
+++ b/PlaygroundAppUITests/XCUIElement+AsyncTests.swift
@@ -1,8 +1,42 @@
-//
-//  XCUIElement+AsyncTests.swift
-//  PlaygroundAppUITests
-//
-//  Created by Gio on 9/12/21.
-//
+import XCUITestHelpers
+import XCTest
 
-import Foundation
+class XCUIElementAsyncTests: XCTestCase {
+
+    let app = XCUIApplication()
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app.launch()
+    }
+
+    func testWaitsForPredicateOnElement() {
+        XCTAssertEqual(
+            app.staticTexts["a"].waitFor(
+                predicate: NSPredicate(format: "isEnabled == true"),
+                timeout: 2 // Interestingly, on Xcode 13.1, a 1 second timeout results in a failure
+            ),
+            .completed
+        )
+        // Test the opposite scenario must also be true.
+        XCTAssertEqual(
+            app.staticTexts["a"].waitFor(
+                predicate: NSPredicate(format: "isEnabled == false"),
+                timeout: 2
+            ),
+            .timedOut
+        )
+    }
+
+    func testWaitsForPredicateFromStringOnElement() {
+        XCTAssertEqual(
+            app.staticTexts["a"].waitFor(predicateString: "isEnabled == true"),
+            .completed
+        )
+        // Test the opposite scenario must also be true.
+        XCTAssertEqual(
+            app.staticTexts["a"].waitFor(predicateString: "isEnabled == false"),
+            .timedOut
+        )
+    }
+}

--- a/Sources/XCUITestHelpers/XCUIElement+Async.swift
+++ b/Sources/XCUITestHelpers/XCUIElement+Async.swift
@@ -12,16 +12,23 @@ extension XCUIElement {
         // Avoid unnecessary waiting if the element is already hittable
         guard isHittable == false else { return true }
 
-        let result = XCTWaiter.wait(
-            for: [
-                XCTNSPredicateExpectation(
-                    predicate: NSPredicate(format: "isHittable == true"),
-                    object: self
-                )
-            ],
+        return waitFor(predicateString: "isHittable == true", timeout: timeout) == .completed
+    }
+
+    /// Uses the given `String` to create an `NSPredicate` and waits for it to be true on `self` for
+    /// the given `timeout` (defaults to 3 seconds)
+    @discardableResult
+    public func waitFor(predicateString: String, timeout: TimeInterval = 3.0) -> XCTWaiter.Result {
+        waitFor(predicate: NSPredicate(format: predicateString), timeout: timeout)
+    }
+
+    /// Waits for the given `NSPredicate` to be true on `self` for the given `timeout` (default to
+    /// 3 seconds)
+    @discardableResult
+    public func waitFor(predicate: NSPredicate, timeout: TimeInterval = 3.0) -> XCTWaiter.Result {
+        XCTWaiter.wait(
+            for: [ XCTNSPredicateExpectation(predicate: predicate, object: self) ],
             timeout: timeout
         )
-
-        return result == .completed
     }
 }

--- a/XCUITestHelpers.xcodeproj/project.pbxproj
+++ b/XCUITestHelpers.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		3F1C9AE326CC9E0E00101E82 /* XCUIElementQuery+Position.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F95FF4726C5425A007731D3 /* XCUIElementQuery+Position.swift */; };
 		3F1C9AE526CCA4B300101E82 /* XCUIElementQueryPositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1C9AE426CCA4B300101E82 /* XCUIElementQueryPositionTests.swift */; };
 		3F1CA82126C3E7A300228BF2 /* XCUIDevice+UserInterfaceIdiom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1CA82026C3E7A300228BF2 /* XCUIDevice+UserInterfaceIdiom.swift */; };
+		3F3A56A427621485001D0C03 /* XCTWaiter.Result+CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3A56A327621485001D0C03 /* XCTWaiter.Result+CustomStringConvertible.swift */; };
 		3F4D7F94275E308000650353 /* XCUIElement+Visibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4D7F93275E308000650353 /* XCUIElement+Visibility.swift */; };
 		3F762E8B26777BAF0088CD45 /* XCUITestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F762E8926777BAF0088CD45 /* XCUITestHelpers.swift */; };
 		3F762E8C26777BAF0088CD45 /* XCUITestHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F762E8A26777BAF0088CD45 /* XCUITestHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -57,6 +58,7 @@
 		3F1C9AE126CC9C9300101E82 /* XCUIApplication+StatusBarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIApplication+StatusBarTests.swift"; sourceTree = "<group>"; };
 		3F1C9AE426CCA4B300101E82 /* XCUIElementQueryPositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCUIElementQueryPositionTests.swift; sourceTree = "<group>"; };
 		3F1CA82026C3E7A300228BF2 /* XCUIDevice+UserInterfaceIdiom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIDevice+UserInterfaceIdiom.swift"; sourceTree = "<group>"; };
+		3F3A56A327621485001D0C03 /* XCTWaiter.Result+CustomStringConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTWaiter.Result+CustomStringConvertible.swift"; sourceTree = "<group>"; };
 		3F4D7F93275E308000650353 /* XCUIElement+Visibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIElement+Visibility.swift"; sourceTree = "<group>"; };
 		3F762E8926777BAF0088CD45 /* XCUITestHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCUITestHelpers.swift; sourceTree = "<group>"; };
 		3F762E8A26777BAF0088CD45 /* XCUITestHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XCUITestHelpers.h; sourceTree = "<group>"; };
@@ -205,6 +207,7 @@
 			children = (
 				3FF1429B266DB85500138163 /* Info.plist */,
 				3FF14299266DB85500138163 /* PlaygroundAppUITests.swift */,
+				3F3A56A327621485001D0C03 /* XCTWaiter.Result+CustomStringConvertible.swift */,
 				3F1C9AE126CC9C9300101E82 /* XCUIApplication+StatusBarTests.swift */,
 				3F8CDAD826C2261F00A4A814 /* XCUIDevice+UserInterfaceStyleTests.swift */,
 				3F95FF4126C534A8007731D3 /* XCUIDeviceUserInterfaceIdiomTests.swift */,
@@ -432,6 +435,7 @@
 				3F95FF4626C53E0D007731D3 /* XCUIElement+Async.swift in Sources */,
 				3FF1429A266DB85500138163 /* PlaygroundAppUITests.swift in Sources */,
 				3F1C9AE226CC9C9300101E82 /* XCUIApplication+StatusBarTests.swift in Sources */,
+				3F3A56A427621485001D0C03 /* XCTWaiter.Result+CustomStringConvertible.swift in Sources */,
 				3F95FF4226C534A8007731D3 /* XCUIDeviceUserInterfaceIdiomTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/XCUITestHelpers.xcodeproj/project.pbxproj
+++ b/XCUITestHelpers.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		3F1C9AE326CC9E0E00101E82 /* XCUIElementQuery+Position.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F95FF4726C5425A007731D3 /* XCUIElementQuery+Position.swift */; };
 		3F1C9AE526CCA4B300101E82 /* XCUIElementQueryPositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1C9AE426CCA4B300101E82 /* XCUIElementQueryPositionTests.swift */; };
 		3F1CA82126C3E7A300228BF2 /* XCUIDevice+UserInterfaceIdiom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1CA82026C3E7A300228BF2 /* XCUIDevice+UserInterfaceIdiom.swift */; };
+		3F3A56A227620E7C001D0C03 /* XCUIElement+AsyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3A56A127620E7C001D0C03 /* XCUIElement+AsyncTests.swift */; };
 		3F3A56A427621485001D0C03 /* XCTWaiter.Result+CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3A56A327621485001D0C03 /* XCTWaiter.Result+CustomStringConvertible.swift */; };
 		3F4D7F94275E308000650353 /* XCUIElement+Visibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4D7F93275E308000650353 /* XCUIElement+Visibility.swift */; };
 		3F762E8B26777BAF0088CD45 /* XCUITestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F762E8926777BAF0088CD45 /* XCUITestHelpers.swift */; };
@@ -58,6 +59,7 @@
 		3F1C9AE126CC9C9300101E82 /* XCUIApplication+StatusBarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIApplication+StatusBarTests.swift"; sourceTree = "<group>"; };
 		3F1C9AE426CCA4B300101E82 /* XCUIElementQueryPositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCUIElementQueryPositionTests.swift; sourceTree = "<group>"; };
 		3F1CA82026C3E7A300228BF2 /* XCUIDevice+UserInterfaceIdiom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIDevice+UserInterfaceIdiom.swift"; sourceTree = "<group>"; };
+		3F3A56A127620E7C001D0C03 /* XCUIElement+AsyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIElement+AsyncTests.swift"; sourceTree = "<group>"; };
 		3F3A56A327621485001D0C03 /* XCTWaiter.Result+CustomStringConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTWaiter.Result+CustomStringConvertible.swift"; sourceTree = "<group>"; };
 		3F4D7F93275E308000650353 /* XCUIElement+Visibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIElement+Visibility.swift"; sourceTree = "<group>"; };
 		3F762E8926777BAF0088CD45 /* XCUITestHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCUITestHelpers.swift; sourceTree = "<group>"; };
@@ -211,6 +213,7 @@
 				3F1C9AE126CC9C9300101E82 /* XCUIApplication+StatusBarTests.swift */,
 				3F8CDAD826C2261F00A4A814 /* XCUIDevice+UserInterfaceStyleTests.swift */,
 				3F95FF4126C534A8007731D3 /* XCUIDeviceUserInterfaceIdiomTests.swift */,
+				3F3A56A127620E7C001D0C03 /* XCUIElement+AsyncTests.swift */,
 				3F1C9AE426CCA4B300101E82 /* XCUIElementQueryPositionTests.swift */,
 			);
 			path = PlaygroundAppUITests;
@@ -435,6 +438,7 @@
 				3F95FF4626C53E0D007731D3 /* XCUIElement+Async.swift in Sources */,
 				3FF1429A266DB85500138163 /* PlaygroundAppUITests.swift in Sources */,
 				3F1C9AE226CC9C9300101E82 /* XCUIApplication+StatusBarTests.swift in Sources */,
+				3F3A56A227620E7C001D0C03 /* XCUIElement+AsyncTests.swift in Sources */,
 				3F3A56A427621485001D0C03 /* XCTWaiter.Result+CustomStringConvertible.swift in Sources */,
 				3F95FF4226C534A8007731D3 /* XCUIDeviceUserInterfaceIdiomTests.swift in Sources */,
 			);


### PR DESCRIPTION
Making good on my promise to extract the code originally in WordPress iOS from [this comment](https://github.com/wordpress-mobile/WordPress-iOS/pull/17361#discussion_r747213024).

You can see it in action in WordPress iOS [here](https://github.com/wordpress-mobile/WordPress-iOS/pull/17654).